### PR TITLE
Fix `seed!` for Xoshiro256

### DIFF
--- a/src/Xorshifts/xoshiro256.jl
+++ b/src/Xorshifts/xoshiro256.jl
@@ -63,7 +63,7 @@ copy(src::T) where T <: AbstractXoshiro256 = copyto!(T(), src)
 
 ==(r1::T, r2::T) where T <: AbstractXoshiro256 = r1.x == r2.x && r1.y == r2.y && r1.z == r2.z && r1.w == r2.w
 
-seed!(r::AbstractXoshiro256, seed::Integer) = seed!(r, init_seed(seed % UInt64))
+seed!(r::AbstractXoshiro256, seed::Integer) = seed!(r, init_seed(seed, UInt64))
 function seed!(r::AbstractXoshiro256, seed::NTuple{4, UInt64}=gen_seed(UInt64, 4))
     all(==(0), seed) && error("0 cannot be the seed")
     r.x = seed[1]


### PR DESCRIPTION
When seeding Xoshiro256 with an integer on 1.5, the following error is produced:

```
ERROR: MethodError: no method matching init_seed(::UInt64)
Closest candidates are:
  init_seed(::Any, ::Type{UInt64}) at /home/m/.julia/packages/RandomNumbers/jCCkY/src/Xorshifts/splitmix64.jl:50
  init_seed(::Any, ::Type{UInt64}, ::Int64) at /home/m/.julia/packages/RandomNumbers/jCCkY/src/Xorshifts/splitmix64.jl:51
  init_seed(::Any, ::Type{UInt32}, ::Int64) at /home/m/.julia/packages/RandomNumbers/jCCkY/src/Xorshifts/splitmix64.jl:58
Stacktrace:
 [1] seed!(r::RandomNumbers.Xorshifts.Xoshiro256StarStar, seed::Int64)
   @ RandomNumbers.Xorshifts ~/.julia/packages/RandomNumbers/jCCkY/src/Xorshifts/xoshiro256.jl:66
 [2] top-level scope
   @ REPL[13]:1
```

This PR fixes it by changing how `init_seed` is called in the `seed!` function.