### PR TITLE
Remove `Random123` as a sub-module

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,14 +2,13 @@ name = "RandomNumbers"
 uuid = "e6cf234a-135c-5ec9-84dd-332b85af5143"
 author = ["Sunoru <s@sunoru.com>"]
 repo = "https://github.com/JuliaRandom/RandomNumbers.jl.git"
-version = "1.5.3"
+version = "1.6.0"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
-Requires = "1"
 julia = "1"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ There are four RNG families in this package:
     A class of RNG based on *exclusive or* and *bit shift*.
 
 Note that `Random123` is now made a separate package as [Random123.jl](https://github.com/JuliaRandom/Random123.jl).
-You can still use your old code with `RandomNumbers.Random123` as long as you import `Random123` manually.
 
 ## Usage
 

--- a/docs/src/man/random123.md
+++ b/docs/src/man/random123.md
@@ -1,9 +1,9 @@
 # Random123 Family
 
 ```@meta
-CurrentModule = RandomNumbers.Random123
+CurrentModule = Random123
 DocTestSetup = quote
-    using RandomNumbers.Random123
+    using Random123
 end
 ```
 
@@ -69,7 +69,7 @@ For detailed usage of each RNG, please refer to the [library docs](@ref Random12
 
 To use Random123, firstly import the module:
 ```julia
-julia> using RandomNumbers.Random123
+julia> using Random123
 ```
 
 Take `Philox4x64` for example:

--- a/src/RandomNumbers.jl
+++ b/src/RandomNumbers.jl
@@ -10,7 +10,6 @@ This module exports two types and four submodules:
 - [`WrappedRNG`](@ref)
 - [`PCG`](@ref)
 - [`MersenneTwisters`](@ref)
-- [`Random123`](random123.md#Random123.Random123)
 - [`Xorshifts`](@ref)
 """
 module RandomNumbers
@@ -18,7 +17,7 @@ module RandomNumbers
     export AbstractRNG
     export WrappedRNG
     export output_type, seed_type
-    export PCG, MersenneTwisters, Random123, Xorshifts
+    export PCG, MersenneTwisters, Xorshifts
 
     include("common.jl")
     include("utils.jl")
@@ -31,11 +30,4 @@ module RandomNumbers
 
     export randfloat
     include("randfloat.jl")
-
-    import Requires
-    function __init__()
-        # The code of Random123 has been moved to Random123.jl
-        Requires.@require Random123="74087812-796a-5b5d-8853-05524746bad3" import .Random123
-    end
-
 end


### PR DESCRIPTION
This usage of Requires.jl is incompatible with the package extensions introduced in Julia 1.9.

Instead, this PR makes a breaking change to get rid of `RandomNumbers.Random123` and push folks to use `Random123` directly.